### PR TITLE
Some trivial enhancements for IDE autocompletion and hinting

### DIFF
--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -97,6 +97,14 @@ class Money
         return $this->precision;
     }
 
+    /**
+     * @return Money
+     */
+    public function copy()
+    {
+        return new Money($this->amount, $this->currency, $this->precision);
+    }
+
 
     /**
      * Convenience factory method for a Money object
@@ -151,9 +159,10 @@ class Money
     public function compare(Money $other)
     {
         $this->assertSameCurrency($other);
-        if ($this->amount < $other->amount) {
+        $otherAmount = $other->toPrecision($this->precision)->amount;
+        if ($this->amount < $otherAmount) {
             return -1;
-        } elseif ($this->amount == $other->amount) {
+        } elseif ($this->amount == $otherAmount) {
             return 0;
         } else {
             return 1;
@@ -229,7 +238,7 @@ class Money
     {
         $this->assertSameCurrency($addend);
 
-        return new self($this->amount + $addend->amount, $this->currency, $this->precision);
+        return new self($this->amount + $addend->toPrecision($this->precision)->amount, $this->currency, $this->precision);
     }
 
     /**
@@ -240,7 +249,7 @@ class Money
     {
         $this->assertSameCurrency($subtrahend);
 
-        return new self($this->amount - $subtrahend->amount, $this->currency, $this->precision);
+        return new self($this->amount - $subtrahend->toPrecision($this->precision)->amount, $this->currency, $this->precision);
     }
 
     /**

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -10,7 +10,7 @@
 
 namespace Money;
 
-class Money extends MoneyFactory
+class Money
 {
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
     const ROUND_HALF_DOWN = PHP_ROUND_HALF_DOWN;

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -108,7 +108,10 @@ class Money
      */
     public static function __callStatic($method, $arguments)
     {
-        return new Money($arguments[0], new Currency($method), @$arguments[1]);
+
+        return  is_int(@$arguments[1]) ?
+                new Money($arguments[0], new Currency($method), $arguments[1]) :
+                new Money($arguments[0], new Currency($method));
     }
 
     /**

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -10,7 +10,7 @@
 
 namespace Money;
 
-class Money
+class Money extends MoneyFactory
 {
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
     const ROUND_HALF_DOWN = PHP_ROUND_HALF_DOWN;
@@ -38,18 +38,6 @@ class Money
         }
         $this->amount = $amount;
         $this->currency = $currency;
-    }
-
-    /**
-     * Convenience factory method for a Money object
-     * @example $fiveDollar = Money::USD(500);
-     * @param string $method
-     * @param array $arguments
-     * @return \Money\Money
-     */
-    public static function __callStatic($method, $arguments)
-    {
-        return new Money($arguments[0], new Currency($method));
     }
 
     /**
@@ -234,7 +222,7 @@ class Money
     /**
      * Allocate the money according to a list of ratio's
      * @param array $ratios List of ratio's
-     * @return \Money\Money
+     * @return \Money\Money[]
      */
     public function allocate(array $ratios)
     {

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -41,6 +41,19 @@ class Money extends MoneyFactory
     }
 
     /**
+     * Convenience factory method for a Money object
+     * For a IDE friendlier alternative, use MoneyFactory
+     * @example $fiveDollar = Money::USD(500);
+     * @param string $method
+     * @param array $arguments
+     * @return \Money\Money
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        return new Money($arguments[0], new Currency($method));
+    }
+
+    /**
      * @param \Money\Money $other
      * @return bool
      */

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -292,6 +292,7 @@ class Money
 
     /**
      * Allocate the money according to a list of ratio's
+     * The resulting array of money objects has the same keys of the ratios array
      * @param array $ratios List of ratio's
      * @param int $precision
      * @return \Money\Money[]
@@ -304,15 +305,17 @@ class Money
         $results = array();
         $total = array_sum($ratios);
 
-        foreach ($ratios as $ratio) {
+        foreach ($ratios as $key => $ratio) {
             $share = (int) floor($amount * $ratio / $total);
-            $results[] = new Money($share, $this->currency, $precision);;
+            $results[$key] = new Money($share, $this->currency, $precision);;
             $remainder -= $share;
         }
 
-        for ($i = 0; $remainder > 0; $i++) {
-            $results[$i]->amount++;
-            $remainder--;
+        foreach($results as &$result) {
+            if($remainder > 0) {
+                $result->amount++;
+                $remainder--;
+            } else break;
         }
 
         return $results;

--- a/lib/Money/MoneyFactory.php
+++ b/lib/Money/MoneyFactory.php
@@ -13,6 +13,47 @@ namespace Money;
 class MoneyFactory
 {
     /**
+     * @var int
+     */
+    protected $precision;
+
+    /**
+     * @var string
+     */
+    protected $defaultCurrency;
+
+    /**
+     * @param int $precision
+     * @param string $defaultCurrency
+     */
+    public function __construct($precision, $defaultCurrency) {
+        $this->precision = $precision;
+        $this->defaultCurrency = $defaultCurrency;
+    }
+
+    /**
+     * @param Money|string $amount
+     * @return Money
+     */
+    public function toMoney($amount)
+    {
+        if($amount instanceof Money)
+            return $amount;
+
+        return Money::fromDecimal($amount, new Currency($this->defaultCurrency), $this->precision);
+    }
+
+
+    /**
+     * @param int $amount
+     * @return Money
+     */
+    public function IntToMoney($amount)
+    {
+        return new Money($amount, new Currency($this->defaultCurrency), $this->precision);
+    }
+
+    /**
      * Convenience factory method for a AED Money object
      * @param int $amount
      * @return \Money\Money

--- a/lib/Money/MoneyFactory.php
+++ b/lib/Money/MoneyFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the Money library
+ *
+ * Copyright (c) 2011-2013 Mathias Verraes
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Money;
+
+abstract class MoneyFactory
+{
+    /**
+     * Convenience factory method for a Money object
+     * @example $fiveDollar = Money::USD(500);
+     * @param string $method
+     * @param array $arguments
+     * @return \Money\Money
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        return new Money($arguments[0], new Currency($method));
+    }
+
+}

--- a/lib/Money/MoneyFactory.php
+++ b/lib/Money/MoneyFactory.php
@@ -10,18 +10,1606 @@
 
 namespace Money;
 
-abstract class MoneyFactory
+class MoneyFactory
 {
     /**
-     * Convenience factory method for a Money object
-     * @example $fiveDollar = Money::USD(500);
-     * @param string $method
-     * @param array $arguments
+     * Convenience factory method for a AED Money object
+     * @param int $amount
      * @return \Money\Money
      */
-    public static function __callStatic($method, $arguments)
+    public static function AED($amount)
     {
-        return new Money($arguments[0], new Currency($method));
+        return new Money($amount, new Currency('AED'));
+    }
+
+    /**
+     * Convenience factory method for a AFN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AFN($amount)
+    {
+        return new Money($amount, new Currency('AFN'));
+    }
+
+    /**
+     * Convenience factory method for a ALL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ALL($amount)
+    {
+        return new Money($amount, new Currency('ALL'));
+    }
+
+    /**
+     * Convenience factory method for a AMD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AMD($amount)
+    {
+        return new Money($amount, new Currency('AMD'));
+    }
+
+    /**
+     * Convenience factory method for a ANG Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ANG($amount)
+    {
+        return new Money($amount, new Currency('ANG'));
+    }
+
+    /**
+     * Convenience factory method for a AOA Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AOA($amount)
+    {
+        return new Money($amount, new Currency('AOA'));
+    }
+
+    /**
+     * Convenience factory method for a ARS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ARS($amount)
+    {
+        return new Money($amount, new Currency('ARS'));
+    }
+
+    /**
+     * Convenience factory method for a AUD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AUD($amount)
+    {
+        return new Money($amount, new Currency('AUD'));
+    }
+
+    /**
+     * Convenience factory method for a AWG Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AWG($amount)
+    {
+        return new Money($amount, new Currency('AWG'));
+    }
+
+    /**
+     * Convenience factory method for a AZN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function AZN($amount)
+    {
+        return new Money($amount, new Currency('AZN'));
+    }
+
+    /**
+     * Convenience factory method for a BAM Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BAM($amount)
+    {
+        return new Money($amount, new Currency('BAM'));
+    }
+
+    /**
+     * Convenience factory method for a BBD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BBD($amount)
+    {
+        return new Money($amount, new Currency('BBD'));
+    }
+
+    /**
+     * Convenience factory method for a BDT Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BDT($amount)
+    {
+        return new Money($amount, new Currency('BDT'));
+    }
+
+    /**
+     * Convenience factory method for a BGN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BGN($amount)
+    {
+        return new Money($amount, new Currency('BGN'));
+    }
+
+    /**
+     * Convenience factory method for a BHD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BHD($amount)
+    {
+        return new Money($amount, new Currency('BHD'));
+    }
+
+    /**
+     * Convenience factory method for a BIF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BIF($amount)
+    {
+        return new Money($amount, new Currency('BIF'));
+    }
+
+    /**
+     * Convenience factory method for a BMD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BMD($amount)
+    {
+        return new Money($amount, new Currency('BMD'));
+    }
+
+    /**
+     * Convenience factory method for a BND Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BND($amount)
+    {
+        return new Money($amount, new Currency('BND'));
+    }
+
+    /**
+     * Convenience factory method for a BOB Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BOB($amount)
+    {
+        return new Money($amount, new Currency('BOB'));
+    }
+
+    /**
+     * Convenience factory method for a BRL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BRL($amount)
+    {
+        return new Money($amount, new Currency('BRL'));
+    }
+
+    /**
+     * Convenience factory method for a BSD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BSD($amount)
+    {
+        return new Money($amount, new Currency('BSD'));
+    }
+
+    /**
+     * Convenience factory method for a BTN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BTN($amount)
+    {
+        return new Money($amount, new Currency('BTN'));
+    }
+
+    /**
+     * Convenience factory method for a BWP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BWP($amount)
+    {
+        return new Money($amount, new Currency('BWP'));
+    }
+
+    /**
+     * Convenience factory method for a BYR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BYR($amount)
+    {
+        return new Money($amount, new Currency('BYR'));
+    }
+
+    /**
+     * Convenience factory method for a BZD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function BZD($amount)
+    {
+        return new Money($amount, new Currency('BZD'));
+    }
+
+    /**
+     * Convenience factory method for a CAD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CAD($amount)
+    {
+        return new Money($amount, new Currency('CAD'));
+    }
+
+    /**
+     * Convenience factory method for a CDF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CDF($amount)
+    {
+        return new Money($amount, new Currency('CDF'));
+    }
+
+    /**
+     * Convenience factory method for a CHF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CHF($amount)
+    {
+        return new Money($amount, new Currency('CHF'));
+    }
+
+    /**
+     * Convenience factory method for a CLF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CLF($amount)
+    {
+        return new Money($amount, new Currency('CLF'));
+    }
+
+    /**
+     * Convenience factory method for a CLP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CLP($amount)
+    {
+        return new Money($amount, new Currency('CLP'));
+    }
+
+    /**
+     * Convenience factory method for a CNY Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CNY($amount)
+    {
+        return new Money($amount, new Currency('CNY'));
+    }
+
+    /**
+     * Convenience factory method for a COP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function COP($amount)
+    {
+        return new Money($amount, new Currency('COP'));
+    }
+
+    /**
+     * Convenience factory method for a CRC Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CRC($amount)
+    {
+        return new Money($amount, new Currency('CRC'));
+    }
+
+    /**
+     * Convenience factory method for a CUP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CUP($amount)
+    {
+        return new Money($amount, new Currency('CUP'));
+    }
+
+    /**
+     * Convenience factory method for a CVE Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CVE($amount)
+    {
+        return new Money($amount, new Currency('CVE'));
+    }
+
+    /**
+     * Convenience factory method for a CZK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function CZK($amount)
+    {
+        return new Money($amount, new Currency('CZK'));
+    }
+
+    /**
+     * Convenience factory method for a DJF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function DJF($amount)
+    {
+        return new Money($amount, new Currency('DJF'));
+    }
+
+    /**
+     * Convenience factory method for a DKK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function DKK($amount)
+    {
+        return new Money($amount, new Currency('DKK'));
+    }
+
+    /**
+     * Convenience factory method for a DOP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function DOP($amount)
+    {
+        return new Money($amount, new Currency('DOP'));
+    }
+
+    /**
+     * Convenience factory method for a DZD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function DZD($amount)
+    {
+        return new Money($amount, new Currency('DZD'));
+    }
+
+    /**
+     * Convenience factory method for a EEK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function EEK($amount)
+    {
+        return new Money($amount, new Currency('EEK'));
+    }
+
+    /**
+     * Convenience factory method for a EGP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function EGP($amount)
+    {
+        return new Money($amount, new Currency('EGP'));
+    }
+
+    /**
+     * Convenience factory method for a ETB Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ETB($amount)
+    {
+        return new Money($amount, new Currency('ETB'));
+    }
+
+    /**
+     * Convenience factory method for a EUR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function EUR($amount)
+    {
+        return new Money($amount, new Currency('EUR'));
+    }
+
+    /**
+     * Convenience factory method for a FJD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function FJD($amount)
+    {
+        return new Money($amount, new Currency('FJD'));
+    }
+
+    /**
+     * Convenience factory method for a FKP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function FKP($amount)
+    {
+        return new Money($amount, new Currency('FKP'));
+    }
+
+    /**
+     * Convenience factory method for a GBP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GBP($amount)
+    {
+        return new Money($amount, new Currency('GBP'));
+    }
+
+    /**
+     * Convenience factory method for a GEL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GEL($amount)
+    {
+        return new Money($amount, new Currency('GEL'));
+    }
+
+    /**
+     * Convenience factory method for a GHS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GHS($amount)
+    {
+        return new Money($amount, new Currency('GHS'));
+    }
+
+    /**
+     * Convenience factory method for a GIP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GIP($amount)
+    {
+        return new Money($amount, new Currency('GIP'));
+    }
+
+    /**
+     * Convenience factory method for a GMD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GMD($amount)
+    {
+        return new Money($amount, new Currency('GMD'));
+    }
+
+    /**
+     * Convenience factory method for a GNF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GNF($amount)
+    {
+        return new Money($amount, new Currency('GNF'));
+    }
+
+    /**
+     * Convenience factory method for a GTQ Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GTQ($amount)
+    {
+        return new Money($amount, new Currency('GTQ'));
+    }
+
+    /**
+     * Convenience factory method for a GYD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function GYD($amount)
+    {
+        return new Money($amount, new Currency('GYD'));
+    }
+
+    /**
+     * Convenience factory method for a HKD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function HKD($amount)
+    {
+        return new Money($amount, new Currency('HKD'));
+    }
+
+    /**
+     * Convenience factory method for a HNL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function HNL($amount)
+    {
+        return new Money($amount, new Currency('HNL'));
+    }
+
+    /**
+     * Convenience factory method for a HRK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function HRK($amount)
+    {
+        return new Money($amount, new Currency('HRK'));
+    }
+
+    /**
+     * Convenience factory method for a HTG Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function HTG($amount)
+    {
+        return new Money($amount, new Currency('HTG'));
+    }
+
+    /**
+     * Convenience factory method for a HUF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function HUF($amount)
+    {
+        return new Money($amount, new Currency('HUF'));
+    }
+
+    /**
+     * Convenience factory method for a IDR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function IDR($amount)
+    {
+        return new Money($amount, new Currency('IDR'));
+    }
+
+    /**
+     * Convenience factory method for a ILS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ILS($amount)
+    {
+        return new Money($amount, new Currency('ILS'));
+    }
+
+    /**
+     * Convenience factory method for a INR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function INR($amount)
+    {
+        return new Money($amount, new Currency('INR'));
+    }
+
+    /**
+     * Convenience factory method for a IQD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function IQD($amount)
+    {
+        return new Money($amount, new Currency('IQD'));
+    }
+
+    /**
+     * Convenience factory method for a IRR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function IRR($amount)
+    {
+        return new Money($amount, new Currency('IRR'));
+    }
+
+    /**
+     * Convenience factory method for a ISK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ISK($amount)
+    {
+        return new Money($amount, new Currency('ISK'));
+    }
+
+    /**
+     * Convenience factory method for a JEP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function JEP($amount)
+    {
+        return new Money($amount, new Currency('JEP'));
+    }
+
+    /**
+     * Convenience factory method for a JMD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function JMD($amount)
+    {
+        return new Money($amount, new Currency('JMD'));
+    }
+
+    /**
+     * Convenience factory method for a JOD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function JOD($amount)
+    {
+        return new Money($amount, new Currency('JOD'));
+    }
+
+    /**
+     * Convenience factory method for a JPY Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function JPY($amount)
+    {
+        return new Money($amount, new Currency('JPY'));
+    }
+
+    /**
+     * Convenience factory method for a KES Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KES($amount)
+    {
+        return new Money($amount, new Currency('KES'));
+    }
+
+    /**
+     * Convenience factory method for a KGS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KGS($amount)
+    {
+        return new Money($amount, new Currency('KGS'));
+    }
+
+    /**
+     * Convenience factory method for a KHR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KHR($amount)
+    {
+        return new Money($amount, new Currency('KHR'));
+    }
+
+    /**
+     * Convenience factory method for a KMF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KMF($amount)
+    {
+        return new Money($amount, new Currency('KMF'));
+    }
+
+    /**
+     * Convenience factory method for a KPW Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KPW($amount)
+    {
+        return new Money($amount, new Currency('KPW'));
+    }
+
+    /**
+     * Convenience factory method for a KRW Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KRW($amount)
+    {
+        return new Money($amount, new Currency('KRW'));
+    }
+
+    /**
+     * Convenience factory method for a KWD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KWD($amount)
+    {
+        return new Money($amount, new Currency('KWD'));
+    }
+
+    /**
+     * Convenience factory method for a KYD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KYD($amount)
+    {
+        return new Money($amount, new Currency('KYD'));
+    }
+
+    /**
+     * Convenience factory method for a KZT Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function KZT($amount)
+    {
+        return new Money($amount, new Currency('KZT'));
+    }
+
+    /**
+     * Convenience factory method for a LAK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LAK($amount)
+    {
+        return new Money($amount, new Currency('LAK'));
+    }
+
+    /**
+     * Convenience factory method for a LBP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LBP($amount)
+    {
+        return new Money($amount, new Currency('LBP'));
+    }
+
+    /**
+     * Convenience factory method for a LKR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LKR($amount)
+    {
+        return new Money($amount, new Currency('LKR'));
+    }
+
+    /**
+     * Convenience factory method for a LRD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LRD($amount)
+    {
+        return new Money($amount, new Currency('LRD'));
+    }
+
+    /**
+     * Convenience factory method for a LSL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LSL($amount)
+    {
+        return new Money($amount, new Currency('LSL'));
+    }
+
+    /**
+     * Convenience factory method for a LTL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LTL($amount)
+    {
+        return new Money($amount, new Currency('LTL'));
+    }
+
+    /**
+     * Convenience factory method for a LVL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LVL($amount)
+    {
+        return new Money($amount, new Currency('LVL'));
+    }
+
+    /**
+     * Convenience factory method for a LYD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function LYD($amount)
+    {
+        return new Money($amount, new Currency('LYD'));
+    }
+
+    /**
+     * Convenience factory method for a MAD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MAD($amount)
+    {
+        return new Money($amount, new Currency('MAD'));
+    }
+
+    /**
+     * Convenience factory method for a MDL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MDL($amount)
+    {
+        return new Money($amount, new Currency('MDL'));
+    }
+
+    /**
+     * Convenience factory method for a MGA Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MGA($amount)
+    {
+        return new Money($amount, new Currency('MGA'));
+    }
+
+    /**
+     * Convenience factory method for a MKD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MKD($amount)
+    {
+        return new Money($amount, new Currency('MKD'));
+    }
+
+    /**
+     * Convenience factory method for a MMK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MMK($amount)
+    {
+        return new Money($amount, new Currency('MMK'));
+    }
+
+    /**
+     * Convenience factory method for a MNT Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MNT($amount)
+    {
+        return new Money($amount, new Currency('MNT'));
+    }
+
+    /**
+     * Convenience factory method for a MOP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MOP($amount)
+    {
+        return new Money($amount, new Currency('MOP'));
+    }
+
+    /**
+     * Convenience factory method for a MRO Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MRO($amount)
+    {
+        return new Money($amount, new Currency('MRO'));
+    }
+
+    /**
+     * Convenience factory method for a MUR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MUR($amount)
+    {
+        return new Money($amount, new Currency('MUR'));
+    }
+
+    /**
+     * Convenience factory method for a MVR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MVR($amount)
+    {
+        return new Money($amount, new Currency('MVR'));
+    }
+
+    /**
+     * Convenience factory method for a MWK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MWK($amount)
+    {
+        return new Money($amount, new Currency('MWK'));
+    }
+
+    /**
+     * Convenience factory method for a MXN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MXN($amount)
+    {
+        return new Money($amount, new Currency('MXN'));
+    }
+
+    /**
+     * Convenience factory method for a MYR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MYR($amount)
+    {
+        return new Money($amount, new Currency('MYR'));
+    }
+
+    /**
+     * Convenience factory method for a MZN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function MZN($amount)
+    {
+        return new Money($amount, new Currency('MZN'));
+    }
+
+    /**
+     * Convenience factory method for a NAD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NAD($amount)
+    {
+        return new Money($amount, new Currency('NAD'));
+    }
+
+    /**
+     * Convenience factory method for a NGN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NGN($amount)
+    {
+        return new Money($amount, new Currency('NGN'));
+    }
+
+    /**
+     * Convenience factory method for a NIO Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NIO($amount)
+    {
+        return new Money($amount, new Currency('NIO'));
+    }
+
+    /**
+     * Convenience factory method for a NOK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NOK($amount)
+    {
+        return new Money($amount, new Currency('NOK'));
+    }
+
+    /**
+     * Convenience factory method for a NPR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NPR($amount)
+    {
+        return new Money($amount, new Currency('NPR'));
+    }
+
+    /**
+     * Convenience factory method for a NZD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function NZD($amount)
+    {
+        return new Money($amount, new Currency('NZD'));
+    }
+
+    /**
+     * Convenience factory method for a OMR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function OMR($amount)
+    {
+        return new Money($amount, new Currency('OMR'));
+    }
+
+    /**
+     * Convenience factory method for a PAB Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PAB($amount)
+    {
+        return new Money($amount, new Currency('PAB'));
+    }
+
+    /**
+     * Convenience factory method for a PEN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PEN($amount)
+    {
+        return new Money($amount, new Currency('PEN'));
+    }
+
+    /**
+     * Convenience factory method for a PGK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PGK($amount)
+    {
+        return new Money($amount, new Currency('PGK'));
+    }
+
+    /**
+     * Convenience factory method for a PHP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PHP($amount)
+    {
+        return new Money($amount, new Currency('PHP'));
+    }
+
+    /**
+     * Convenience factory method for a PKR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PKR($amount)
+    {
+        return new Money($amount, new Currency('PKR'));
+    }
+
+    /**
+     * Convenience factory method for a PLN Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PLN($amount)
+    {
+        return new Money($amount, new Currency('PLN'));
+    }
+
+    /**
+     * Convenience factory method for a PYG Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function PYG($amount)
+    {
+        return new Money($amount, new Currency('PYG'));
+    }
+
+    /**
+     * Convenience factory method for a QAR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function QAR($amount)
+    {
+        return new Money($amount, new Currency('QAR'));
+    }
+
+    /**
+     * Convenience factory method for a RON Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function RON($amount)
+    {
+        return new Money($amount, new Currency('RON'));
+    }
+
+    /**
+     * Convenience factory method for a RSD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function RSD($amount)
+    {
+        return new Money($amount, new Currency('RSD'));
+    }
+
+    /**
+     * Convenience factory method for a RUB Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function RUB($amount)
+    {
+        return new Money($amount, new Currency('RUB'));
+    }
+
+    /**
+     * Convenience factory method for a RWF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function RWF($amount)
+    {
+        return new Money($amount, new Currency('RWF'));
+    }
+
+    /**
+     * Convenience factory method for a SAR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SAR($amount)
+    {
+        return new Money($amount, new Currency('SAR'));
+    }
+
+    /**
+     * Convenience factory method for a SBD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SBD($amount)
+    {
+        return new Money($amount, new Currency('SBD'));
+    }
+
+    /**
+     * Convenience factory method for a SCR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SCR($amount)
+    {
+        return new Money($amount, new Currency('SCR'));
+    }
+
+    /**
+     * Convenience factory method for a SDG Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SDG($amount)
+    {
+        return new Money($amount, new Currency('SDG'));
+    }
+
+    /**
+     * Convenience factory method for a SEK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SEK($amount)
+    {
+        return new Money($amount, new Currency('SEK'));
+    }
+
+    /**
+     * Convenience factory method for a SGD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SGD($amount)
+    {
+        return new Money($amount, new Currency('SGD'));
+    }
+
+    /**
+     * Convenience factory method for a SHP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SHP($amount)
+    {
+        return new Money($amount, new Currency('SHP'));
+    }
+
+    /**
+     * Convenience factory method for a SLL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SLL($amount)
+    {
+        return new Money($amount, new Currency('SLL'));
+    }
+
+    /**
+     * Convenience factory method for a SOS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SOS($amount)
+    {
+        return new Money($amount, new Currency('SOS'));
+    }
+
+    /**
+     * Convenience factory method for a SRD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SRD($amount)
+    {
+        return new Money($amount, new Currency('SRD'));
+    }
+
+    /**
+     * Convenience factory method for a STD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function STD($amount)
+    {
+        return new Money($amount, new Currency('STD'));
+    }
+
+    /**
+     * Convenience factory method for a SVC Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SVC($amount)
+    {
+        return new Money($amount, new Currency('SVC'));
+    }
+
+    /**
+     * Convenience factory method for a SYP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SYP($amount)
+    {
+        return new Money($amount, new Currency('SYP'));
+    }
+
+    /**
+     * Convenience factory method for a SZL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function SZL($amount)
+    {
+        return new Money($amount, new Currency('SZL'));
+    }
+
+    /**
+     * Convenience factory method for a THB Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function THB($amount)
+    {
+        return new Money($amount, new Currency('THB'));
+    }
+
+    /**
+     * Convenience factory method for a TJS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TJS($amount)
+    {
+        return new Money($amount, new Currency('TJS'));
+    }
+
+    /**
+     * Convenience factory method for a TMT Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TMT($amount)
+    {
+        return new Money($amount, new Currency('TMT'));
+    }
+
+    /**
+     * Convenience factory method for a TND Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TND($amount)
+    {
+        return new Money($amount, new Currency('TND'));
+    }
+
+    /**
+     * Convenience factory method for a TOP Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TOP($amount)
+    {
+        return new Money($amount, new Currency('TOP'));
+    }
+
+    /**
+     * Convenience factory method for a TRY Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TRY_($amount)
+    {
+        return new Money($amount, new Currency('TRY'));
+    }
+
+    /**
+     * Convenience factory method for a TTD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TTD($amount)
+    {
+        return new Money($amount, new Currency('TTD'));
+    }
+
+    /**
+     * Convenience factory method for a TWD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TWD($amount)
+    {
+        return new Money($amount, new Currency('TWD'));
+    }
+
+    /**
+     * Convenience factory method for a TZS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function TZS($amount)
+    {
+        return new Money($amount, new Currency('TZS'));
+    }
+
+    /**
+     * Convenience factory method for a UAH Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function UAH($amount)
+    {
+        return new Money($amount, new Currency('UAH'));
+    }
+
+    /**
+     * Convenience factory method for a UGX Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function UGX($amount)
+    {
+        return new Money($amount, new Currency('UGX'));
+    }
+
+    /**
+     * Convenience factory method for a USD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function USD($amount)
+    {
+        return new Money($amount, new Currency('USD'));
+    }
+
+    /**
+     * Convenience factory method for a UYU Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function UYU($amount)
+    {
+        return new Money($amount, new Currency('UYU'));
+    }
+
+    /**
+     * Convenience factory method for a UZS Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function UZS($amount)
+    {
+        return new Money($amount, new Currency('UZS'));
+    }
+
+    /**
+     * Convenience factory method for a VEF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function VEF($amount)
+    {
+        return new Money($amount, new Currency('VEF'));
+    }
+
+    /**
+     * Convenience factory method for a VND Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function VND($amount)
+    {
+        return new Money($amount, new Currency('VND'));
+    }
+
+    /**
+     * Convenience factory method for a VUV Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function VUV($amount)
+    {
+        return new Money($amount, new Currency('VUV'));
+    }
+
+    /**
+     * Convenience factory method for a WST Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function WST($amount)
+    {
+        return new Money($amount, new Currency('WST'));
+    }
+
+    /**
+     * Convenience factory method for a XAF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function XAF($amount)
+    {
+        return new Money($amount, new Currency('XAF'));
+    }
+
+    /**
+     * Convenience factory method for a XCD Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function XCD($amount)
+    {
+        return new Money($amount, new Currency('XCD'));
+    }
+
+    /**
+     * Convenience factory method for a XDR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function XDR($amount)
+    {
+        return new Money($amount, new Currency('XDR'));
+    }
+
+    /**
+     * Convenience factory method for a XOF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function XOF($amount)
+    {
+        return new Money($amount, new Currency('XOF'));
+    }
+
+    /**
+     * Convenience factory method for a XPF Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function XPF($amount)
+    {
+        return new Money($amount, new Currency('XPF'));
+    }
+
+    /**
+     * Convenience factory method for a YER Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function YER($amount)
+    {
+        return new Money($amount, new Currency('YER'));
+    }
+
+    /**
+     * Convenience factory method for a ZAR Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ZAR($amount)
+    {
+        return new Money($amount, new Currency('ZAR'));
+    }
+
+    /**
+     * Convenience factory method for a ZMK Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ZMK($amount)
+    {
+        return new Money($amount, new Currency('ZMK'));
+    }
+
+    /**
+     * Convenience factory method for a ZWL Money object
+     * @param int $amount
+     * @return \Money\Money
+     */
+    public static function ZWL($amount)
+    {
+        return new Money($amount, new Currency('ZWL'));
     }
 
 }

--- a/tests/Money/Tests/MoneyTest.php
+++ b/tests/Money/Tests/MoneyTest.php
@@ -198,6 +198,14 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Money(1, new Currency('EUR')), $part2);
     }
 
+    public function testAllocationKeysAreImportantToo()
+    {
+        $m = new Money(50, new Currency('EUR'));
+        $ratios = array( 'key1' => 10, 'key2' => 20 );
+        $allocated = $m->allocate($ratios);
+        $this->assertEquals(array_keys($ratios), array_keys($allocated));
+    }
+
     public function testComparators()
     {
         $this->assertTrue(Money::EUR(0)->isZero());


### PR DESCRIPTION
Hi! I've added a proper static factory and corrected the @result of Money::distribute so that IDEs (PhpStorm) can understand the code better.

$fiveEur = MoneyFactory::EUR(500);
$tenEur = $fiveEur->add($fiveEur); //IDE recognizes $tenEur as a Money instance
$parts = $tenEur->allocate(array(1, 1, 1));
$parts[0]->//(IDE here now suggests correctly)