### PR TITLE
Move currencies load out of construct

### DIFF
--- a/lib/Money/Currency.php
+++ b/lib/Money/Currency.php
@@ -24,9 +24,7 @@ class Currency
      */
     public function __construct($name)
     {
-        if(!isset(static::$currencies)) {
-           static::$currencies = require __DIR__.'/currencies.php';
-        }
+        static::getCurrencies();
 
         if (!array_key_exists($name, static::$currencies)) {
             throw new UnknownCurrencyException($name);
@@ -34,6 +32,17 @@ class Currency
         $this->name = $name;
     }
 
+    /**
+     * @return array
+     */
+    public static function getCurrencies()
+    {
+        if(!isset(static::$currencies)) {
+            static::$currencies = require __DIR__.'/currencies.php';
+        }
+        
+        return static::$currencies;
+    }
 
     /**
      * @return string

--- a/lib/Money/Currency.php
+++ b/lib/Money/Currency.php
@@ -24,11 +24,12 @@ class Currency
      */
     public function __construct($name)
     {
-        static::getCurrencies();
+        $currencies = static::getCurrencies();
 
-        if (!array_key_exists($name, static::$currencies)) {
+        if (!array_key_exists($name, $currencies)) {
             throw new UnknownCurrencyException($name);
         }
+        
         $this->name = $name;
     }
 
@@ -40,7 +41,7 @@ class Currency
         if(!isset(static::$currencies)) {
             static::$currencies = require __DIR__.'/currencies.php';
         }
-        
+
         return static::$currencies;
     }
 


### PR DESCRIPTION
it will be nice to have the currencies available in a static method, so we can integrate the same currency list elsewhere by using the ```Currency``` API rather than loading the file manually (which would cause path problems).

__If we add this method, the include will be always relative to this module directory, no matter if the module is the /vendor/foo/bar/Money or /vendor/foo/bar/baz/Money__, plus it is fully backwards compatible, so... why not?