### PR TITLE
[RFC] Add CurrencyInterface and CurrencyLoader

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -20,7 +20,7 @@ use JsonSerializable;
  *
  * @author Mathias Verraes
  */
-final class Currency implements JsonSerializable
+final class Currency implements CurrencyInterface
 {
     /**
      * Currency code
@@ -70,9 +70,9 @@ final class Currency implements JsonSerializable
      *
      * @return boolean
      */
-    public function equals(Currency $other)
+    public function equals(CurrencyInterface $other)
     {
-        return $this->code === $other->code;
+        return $this->code === $other->getCode();
     }
 
     /**

--- a/src/CurrencyInterface.php
+++ b/src/CurrencyInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the Money library.
+ *
+ * Copyright (c) 2011-2014 Mathias Verraes
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Money;
+
+use JsonSerializable;
+
+/**
+ * Currency Value Object interface
+ *
+ * Holds Currency specific data
+ *
+ * @author Mathias Verraes
+ */
+interface CurrencyInterface extends JsonSerializable
+{
+    /**
+     * Returns the currency code
+     *
+     * @return string
+     *
+     * @deprecated Use getCode() instead
+     */
+    public function getName();
+
+    /**
+     * Returns the currency code
+     *
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * Checks whether this currency is the same as an other
+     *
+     * @param Currency $other
+     *
+     * @return boolean
+     */
+    public function equals(CurrencyInterface $other);
+
+    /**
+     * Checks whether this currency is available in the passed context
+     *
+     * @param AvailableCurrencies $currencies
+     *
+     * @return boolean
+     */
+    public function isAvailableWithin(AvailableCurrencies $currencies);
+
+    /**
+     * @return string
+     */
+    public function __toString();
+}

--- a/src/CurrencyLoader.php
+++ b/src/CurrencyLoader.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Money;
+
+interface CurrencyLoader
+{
+    public function load($code);
+}

--- a/src/ISOCurrencyLoader.php
+++ b/src/ISOCurrencyLoader.php
@@ -1,0 +1,26 @@
+<?php
+namespace Money;
+
+class ISOCurrencyLoader implements CurrencyLoader
+{
+    /**
+     * List of known currencies
+     *
+     * @var array
+     */
+    private $currencies;
+
+    public function __construct()
+    {
+        $this->currencies = require __DIR__.'/currencies.php';
+    }
+
+    public function load($code)
+    {
+        if (! isset($this->currencies[$code])) {
+            throw new UnknownCurrencyException(sprintf("Failed to load currency '%s': not a valid ISO4217 code", $code));
+        }
+
+        return new Currency($code);
+    }
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -42,12 +42,17 @@ final class Money implements JsonSerializable
     private $currency;
 
     /**
+     * @var CurrencyLoader
+     */
+    private static $currencyLoader;
+
+    /**
      * @param int  $amount   Amount, expressed in the smallest units of $currency (eg cents)
      * @param Currency $currency
      *
      * @throws InvalidArgumentException If amount is not integer
      */
-    public function __construct($amount, Currency $currency)
+    public function __construct($amount, CurrencyInterface $currency)
     {
         if (!is_int($amount)) {
             throw new InvalidArgumentException('Amount must be an integer');
@@ -71,7 +76,20 @@ final class Money implements JsonSerializable
      */
     public static function __callStatic($method, $arguments)
     {
-        return new Money($arguments[0], new Currency($method));
+        if (null === self::$currencyLoader) {
+            self::registerLoader(new ISOCurrencyLoader());
+        }
+
+        return new Money($arguments[0], self::$currencyLoader->load($method));
+    }
+
+    public static function registerLoader(CurrencyLoader $loader)
+    {
+        $previous = self::$currencyLoader;
+
+        self::$currencyLoader = $loader;
+
+        return $previous;
     }
 
     /**
@@ -164,7 +182,7 @@ final class Money implements JsonSerializable
     {
         return 0 >= $this->compare($other);
     }
-    
+
     /**
      * Checks whether the value represented by this object is less than the other
      *
@@ -176,7 +194,7 @@ final class Money implements JsonSerializable
     {
         return -1 == $this->compare($other);
     }
-    
+
     /**
      * @param \Money\Money $other
      * @return bool

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -56,6 +56,15 @@ final class CurrencyTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->euro1->equals($this->euro2));
         $this->assertTrue($this->usd1->equals($this->usd2));
+
+        $anotherEur = $this->getMock('Money\CurrencyInterface');
+        $anotherEur
+            ->expects($this->once())
+            ->method('getCode')
+            ->will($this->returnValue('EUR'))
+        ;
+
+        $this->assertTrue($this->euro1->equals($anotherEur));
     }
 
     /**


### PR DESCRIPTION
I've shared with you my fork, since I really think this will improve the library usability (i.e. integration is existing systems).

First and foremost: the implementation of the `Money` class is great! Invariant Final Value Object are great for money, and prevent silly update-by-reference errors.

The main limitation I found is the `Currency` class. The current limitation are:
* all currencies are pre-loaded, no matter how or when you use it (see my issue #94);
* currencies include all(?) and only ISO code, so you cannot use "imaginary currencies" (gold, credit, HyruleRupees, ... you said in another PR that can be done, but I can't see how probably)
* currency only property is the code, and... well... that's not very useful.

The solution seems simple at first: replace or wrap (not extend!) the default currency, and provide my decorated version!

But this is not possibile, for multiple reasons:
* Money class depends on `Currency` implementation, not to abstraction, and so there is no way of providing new behaviour (no Dependency inversion);
* Money class allocate Currency instances directly (Multiple Responsibilities);
* it is bound to a specific set of currencies, since only so I cannot even add currency if I use this implementation (not Open/Closed).

I know, that you did this to provide Immutable Value Object instances, and this is great when it comes to money, but for Currency, the Immutability condition is not required (as long you don't change the currency code, of course); as in the [original Value Object Pattern](http://martinfowler.com/bliki/ValueObject.html), value Object only require that object are compared by value, immutability is just a good heuristic.

So, what have I done to the library?
* Currency is a `final` implementation of `CurrencyInterface`;
* Money depends on `CurrencyInterface`;
* Money class use an instance of `CurrencyLoader` to allocate currency (preconfigured with ISO code for backward compatibility);

All tests still pass and it is fully backward compatible. The only drawback I can think of is that if an application use a custom implementation of Currency, it should not change the currency code at runtime if there are Money instances.

To avoid BC I left the following things which I'm not "proud" of:
* use `Currency`+`CurrencyInterface` instead of `Currency`+`ISOCurrency` (or `DefaultCurrency`);
* `Money::registerLoader` automatically initialize with `ISOCurrencyLoader`;
* config file `currencies.php` is included twice in  `ISOCurrencyLoader` and `ISOCurrencies`;
* `Currency::getName` is deprecated for code, and should be reused to return the ISO name.

I hope to hear your feedback, and maybe the feedback from the community.

Related PR:
* #71 for iso loader implementation
* #94 lazy loading
* #53 where you and @sagikazarmark discussed this same patch. [edited ticket number]
