### PR TITLE
MoneyFormatter #107

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,16 @@
         "kriswallsmith/buzz": "~0.15",
         "phpunit/phpunit": "^4.5",
         "ext-bcmath": "*",
-        "ext-gmp": "*"
+        "ext-gmp": "*",
+        "ext-intl": "*"
     },
     "suggest": {
         "TheBigBrainsCompany/TbbcMoneyBundle": "Very complete Symfony2 bundle with support for Twig, Doctrine, Forms, ...",
         "pink-tie/money-bundle": "Pink-Tie's Symfony2 integration with Money library",
         "Sylius/SyliusMoneyBundle": "Sylius' Symfony2 integration with Money library",
         "ext-bcmath": "Calculate without integer limits",
-        "ext-gmp": "Calculate without integer limits"
+        "ext-gmp": "Calculate without integer limits",
+        "ext-intl": "Format Money objects with intl"
     },
     "autoload": {
         "psr-4": {

--- a/src/IntlMoneyFormatter.php
+++ b/src/IntlMoneyFormatter.php
@@ -1,0 +1,51 @@
+<?php
+namespace Money;
+
+final class IntlMoneyFormatter implements MoneyFormatter {
+
+    /**
+     * @var string
+     */
+    private $locale;
+    /**
+     * @var int
+     */
+    private $fractionDigits;
+
+    /**
+     * IntlMoneyFormatter constructor.
+     * @param int $fractionDigits
+     * @param string $locale
+     */
+    public function __construct($locale, $fractionDigits)
+    {
+        if (extension_loaded('intl') === false) {
+            throw new \RuntimeException(
+                'Cannot initialize IntlMoneyFormatter because intl extension is missing'
+            );
+        }
+
+        $this->locale = $locale;
+        $this->fractionDigits = $fractionDigits;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function format(Money $money)
+    {
+        $valueBase = (string) $money->getAmount();
+        $valueLength = strlen($valueBase);
+        if ($valueLength > $this->fractionDigits) {
+            $subunits = substr($valueBase, 0, $valueLength - $this->fractionDigits) . '.';
+            $subunits .= substr($valueBase, $valueLength - $this->fractionDigits);
+        } else {
+            $subunits = "0." . str_pad('', $this->fractionDigits - $valueLength, '0') . $valueBase;
+        }
+
+
+        $formatter = new \NumberFormatter($this->locale, \NumberFormatter::CURRENCY);
+        $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $this->fractionDigits);
+        return $formatter->formatCurrency($subunits, $money->getCurrency()->getCode());
+    }
+}

--- a/src/MoneyFormatter.php
+++ b/src/MoneyFormatter.php
@@ -1,0 +1,12 @@
+<?php
+namespace Money;
+
+interface MoneyFormatter {
+
+    /**
+     * @param Money $money
+     * @return string
+     */
+    public function format(Money $money);
+
+}

--- a/tests/MoneyFormatterTest.php
+++ b/tests/MoneyFormatterTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of the Money library
+ *
+ * Copyright (c) 2011-2013 Mathias Verraes
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Money\Tests;
+
+use Money\Currency;
+use Money\IntlMoneyFormatter;
+use Money\Money;
+use PHPUnit_Framework_TestCase;
+
+class MoneyFormatterTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testRoundMoney () {
+        $money = new Money(100, new Currency('EUR'));
+        $formatter = new IntlMoneyFormatter('nl_NL', 2);
+        $this->assertEquals('€ 1,00', $formatter->format($money));
+    }
+
+    public function testLessThanOneHundred () {
+        $money = new Money(41, new Currency('EUR'));
+        $formatter = new IntlMoneyFormatter('nl_NL', 2);
+        $this->assertEquals('€ 0,41', $formatter->format($money));
+    }
+
+    public function testLessThanTen () {
+        $money = new Money(5, new Currency('EUR'));
+        $formatter = new IntlMoneyFormatter('nl_NL', 2);
+        $this->assertEquals('€ 0,05', $formatter->format($money));
+    }
+
+    public function testDifferentDigits () {
+        $formatter = new IntlMoneyFormatter('nl_NL', 3);
+        $this->assertEquals('€ 0,005', $formatter->format(new Money(5, new Currency('EUR'))));
+        $this->assertEquals('€ 0,035', $formatter->format(new Money(35, new Currency('EUR'))));
+        $this->assertEquals('€ 0,135', $formatter->format(new Money(135, new Currency('EUR'))));
+        $this->assertEquals('€ 6,135', $formatter->format(new Money(6135, new Currency('EUR'))));
+    }
+
+}


### PR DESCRIPTION
Adds requested feature in #107.

Considerations:
1. No additional dependencies added. If someone wants to use a [ISO4217 package](https://github.com/alcohol/iso4217), it will be easy. Just inject the correct values in the constructor of `IntlMoneyFormatter` (preferably via a factory class).
2. It should work for all different calculators, so we have to work with strings (not integers).
3. `ext/intl` is a suggestion, not a requirement. Though using `IntlMoneyFormatter` without `ext/intl` installed, will throw an exception.