### PR TITLE
fix static calculator and some code style

### DIFF
--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace Money;
 
 /**
  * Calculator Interface
+ *
  * @author Frederik Bosch
  */
 interface Calculator
@@ -94,5 +96,4 @@ interface Calculator
      * @return int|string
      */
     public function share($amount, $ratio, $total);
-
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -35,7 +35,7 @@ final class Money implements JsonSerializable
     /**
      * @var Calculator
      */
-    private $calculator;
+    private static $calculator;
 
     /**
      * @var array
@@ -302,7 +302,6 @@ final class Money implements JsonSerializable
     public function multiply($multiplier, $roundingMode = self::ROUND_HALF_UP)
     {
         $this->assertOperand($multiplier);
-
         $this->assertRoundingMode($roundingMode);
 
         $product = $this->round($this->getCalculator()->multiply($this->amount, $multiplier), $roundingMode);
@@ -321,6 +320,7 @@ final class Money implements JsonSerializable
     {
         $this->assertRoundingMode($roundingMode);
         $amount = $this->getCalculator()->round($this->getCalculator()->multiply($this->amount, $conversionRate), $roundingMode);
+
         return new Money($amount, $targetCurrency);
     }
 
@@ -514,10 +514,10 @@ final class Money implements JsonSerializable
      */
     private function getCalculator()
     {
-        if ($this->calculator === null) {
-            $this->calculator = self::initializeCalculator();
+        if (self::$calculator === null) {
+            self::$calculator = self::initializeCalculator();
         }
 
-        return $this->calculator;
+        return self::$calculator;
     }
 }

--- a/src/Number.php
+++ b/src/Number.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Money;
 
 /**
  * Class Number
- * @package Money
  */
 final class Number
 {
@@ -94,5 +94,4 @@ final class Number
     {
         return $this->number;
     }
-
 }


### PR DESCRIPTION
Using static properties with eg. doctrine integration is not possible.
Some example: i use Money as embedded class and get it from entity. 
```php
$entity->getMoney()->greaterThanOrEqual($otherEntity->getMoney());
```
Currently it is impossible and generate fatal error because constructior is not triggered:
```php
Fatal error: Call to a member function compare() on null
```