### PR TITLE
Add in South Sudanese Pound (SSP)

### DIFF
--- a/lib/Money/currencies.php
+++ b/lib/Money/currencies.php
@@ -136,6 +136,7 @@ return array(
 	"SLL" => "Sierra Leonean Leone",
 	"SOS" => "Somali Shilling",
 	"SRD" => "Surinamese Dollar",
+	"SSP" => "South Sudanese Pound",
 	"STD" => "São Tomé and Príncipe Dobra",
 	"SVC" => "Salvadoran Colón",
 	"SYP" => "Syrian Pound",


### PR DESCRIPTION
This is the official currency of the country of South Sudan - https://en.wikipedia.org/wiki/South_Sudanese_pound