### PR TITLE
Add Money exchange

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-bcmath": "*",
         "ext-gmp": "*",
         "ext-intl": "*",
+        "florianv/swap": "^2.3",
         "fabpot/php-cs-fixer": "^1.11"
     },
     "suggest": {
@@ -28,7 +29,8 @@
         "Sylius/SyliusMoneyBundle": "Sylius' Symfony2 integration with Money library",
         "ext-bcmath": "Calculate without integer limits",
         "ext-gmp": "Calculate without integer limits",
-        "ext-intl": "Format Money objects with intl"
+        "ext-intl": "Format Money objects with intl",
+        "florianv/swap": "Exchange rates library for PHP"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exception/UnresolvableCurrencyPairException.php
+++ b/src/Exception/UnresolvableCurrencyPairException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Money\Exception;
+
+use Money\Currency;
+
+/**
+ * Thrown when there is no currency pair (rate) available for the given currencies.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class UnresolvableCurrencyPairException extends \Exception
+{
+    /**
+     * Creates an exception from Currency objects.
+     *
+     * @param Currency $baseCurrency
+     * @param Currency $counterCurrency
+     *
+     * @return UnresolvableCurrencyPairException
+     */
+    public static function createFromCurrencies(Currency $baseCurrency, Currency $counterCurrency)
+    {
+        $message = sprintf(
+            'Cannot resolve a currency pair for currencies: %s/%s',
+            $baseCurrency->getCode(),
+            $counterCurrency->getCode()
+        );
+
+        return new self($message);
+    }
+}

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Money;
+
+use Money\Exception\UnresolvableCurrencyPairException;
+
+/**
+ * Provides a way to get exchange rate from a third-party source and return a currency pair.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+interface Exchange
+{
+    /**
+     * Returns a currency pair for the passed currencies with the rate coming from a third-party source.
+     *
+     * @param Currency $baseCurrency
+     * @param Currency $counterCurrency
+     *
+     * @return CurrencyPair
+     *
+     * @throws UnresolvableCurrencyPairException When there is no currency pair (rate) available for the given currencies.
+     */
+    public function getCurrencyPair(Currency $baseCurrency, Currency $counterCurrency);
+}

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Money\Exchange;
+
+use Money\Currency;
+use Money\CurrencyPair;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange;
+use Swap\Exception\Exception as SwapException;
+use Swap\Model\CurrencyPair as SwapCurrencyPair;
+use Swap\SwapInterface;
+
+/**
+ * Provides a way to get exchange rate from a third-party source and return a currency pair.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class SwapExchange implements Exchange
+{
+    /**
+     * @var SwapInterface
+     */
+    private $swap;
+
+    /**
+     * @param SwapInterface $swap
+     */
+    public function __construct(SwapInterface $swap)
+    {
+        $this->swap = $swap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrencyPair(Currency $baseCurrency, Currency $counterCurrency)
+    {
+        $swapCurrencyPair = new SwapCurrencyPair($baseCurrency->getCode(), $counterCurrency->getCode());
+
+        try {
+            $rate = $this->swap->quote($swapCurrencyPair);
+        } catch (SwapException $e) {
+            throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
+        }
+
+        return new CurrencyPair($baseCurrency, $counterCurrency, $rate->getValue());
+    }
+}

--- a/tests/Exception/UnresolvableCurrencyPairExceptionTest.php
+++ b/tests/Exception/UnresolvableCurrencyPairExceptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Money\Exception;
+
+use Money\Currency;
+use Money\Exception\UnresolvableCurrencyPairException;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class UnresolvableCurrencyPairExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStaticFactory()
+    {
+        $baseCurrency = new Currency('EUR');
+        $counterCurrency = new Currency('NOPE');
+
+        $e = UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
+
+        $this->assertEquals(
+            'Cannot resolve a currency pair for currencies: EUR/NOPE',
+            $e->getMessage()
+        );
+    }
+}

--- a/tests/Exchange/SwapExchangeTest.php
+++ b/tests/Exchange/SwapExchangeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Money\Exchange;
+
+use Money\Currency;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange\SwapExchange;
+use Prophecy\Argument;
+use Swap\Model\Rate;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class SwapExchangeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCurrencyPairReturned()
+    {
+        $baseCurrency = new Currency('EUR');
+        $counterCurrency = new Currency('USD');
+
+        $rate = new Rate(1.0, new \DateTime());
+
+        $swap = $this->prophesize('Swap\SwapInterface');
+        $swap->quote(Argument::type('Swap\Model\CurrencyPair'))->willReturn($rate);
+
+        $exchange = new SwapExchange($swap->reveal());
+
+        $currencyPair = $exchange->getCurrencyPair($baseCurrency, $counterCurrency);
+
+        $this->assertSame(
+            $baseCurrency,
+            $currencyPair->getBaseCurrency()
+        );
+
+        $this->assertSame(
+            $counterCurrency,
+            $currencyPair->getCounterCurrency()
+        );
+
+        $this->assertSame(
+            1.0,
+            $currencyPair->getConversionRatio()
+        );
+    }
+
+    /**
+     * @expectedException Money\Exception\UnresolvableCurrencyPairException
+     */
+    public function testInvalidCurrencyPair()
+    {
+        $baseCurrency = new Currency('EUR');
+        $counterCurrency = new Currency('NOPE');
+
+        $swap = $this->prophesize('Swap\SwapInterface');
+        $swap->quote(Argument::type('Swap\Model\CurrencyPair'))->willThrow('Swap\Exception\Exception');
+
+        $exchange = new SwapExchange($swap->reveal());
+
+        $exchange->getCurrencyPair($baseCurrency, $counterCurrency);
+    }
+}


### PR DESCRIPTION
Support money exchange services with third-party data sources.

Added https://github.com/florianv/swap as a default implementation.

This also seem to solve florianv/swap#15. Although it is not a separate library, but I think still flexible from Money point of view: one is not tied to a specific implementation.